### PR TITLE
Allow for running Seedance 1 Pro

### DIFF
--- a/nodes/video_node.py
+++ b/nodes/video_node.py
@@ -1057,6 +1057,7 @@ class SeedanceImageToVideoNode:
                 "resolution": (["480p", "720p"], {"default": "720p"}),
                 "duration": (["5", "10"], {"default": "5"}),
                 "camera_fixed": ("BOOLEAN", {"default": False}),
+                "variant": (["lite", "pro"], {"default": "lite"}),
             },
             "optional": {
                 "seed": ("INT", {"default": -1, "min": -1, "max": 2147483647}),
@@ -1067,12 +1068,12 @@ class SeedanceImageToVideoNode:
     FUNCTION = "generate_video"
     CATEGORY = "FAL/VideoGeneration"
 
-    def generate_video(self, prompt, image, resolution, duration, camera_fixed, seed=-1):
+    def generate_video(self, prompt, image, resolution, duration, camera_fixed, seed=-1, variant="lite"):
         try:
             image_url = ImageUtils.upload_image(image)
             if not image_url:
                 return ApiHandler.handle_video_generation_error(
-                    "fal-ai/bytedance/seedance/v1/lite/image-to-video",
+                    f"fal-ai/bytedance/seedance/v1/{variant}/image-to-video",
                     "Failed to upload image",
                 )
 
@@ -1089,13 +1090,13 @@ class SeedanceImageToVideoNode:
                 arguments["seed"] = seed
 
             result = ApiHandler.submit_and_get_result(
-                "fal-ai/bytedance/seedance/v1/lite/image-to-video", arguments
+                f"fal-ai/bytedance/seedance/v1/{variant}/image-to-video", arguments
             )
             video_url = result["video"]["url"]
             return (video_url,)
         except Exception as e:
             return ApiHandler.handle_video_generation_error(
-                "fal-ai/bytedance/seedance/v1/lite/image-to-video", str(e)
+                f"fal-ai/bytedance/seedance/v1/{variant}/image-to-video", str(e)
             )
 
 
@@ -1109,6 +1110,7 @@ class SeedanceTextToVideoNode:
                 "resolution": (["480p", "720p"], {"default": "720p"}),
                 "duration": (["5", "10"], {"default": "5"}),
                 "camera_fixed": ("BOOLEAN", {"default": False}),
+                "variant": (["lite", "pro"], {"default": "lite"}),
             },
             "optional": {
                 "seed": ("INT", {"default": -1, "min": -1, "max": 2147483647}),
@@ -1119,7 +1121,7 @@ class SeedanceTextToVideoNode:
     FUNCTION = "generate_video"
     CATEGORY = "FAL/VideoGeneration"
 
-    def generate_video(self, prompt, aspect_ratio, resolution, duration, camera_fixed, seed=-1):
+    def generate_video(self, prompt, aspect_ratio, resolution, duration, camera_fixed, seed=-1, variant="lite"):
         try:
             arguments = {
                 "prompt": prompt,
@@ -1134,13 +1136,13 @@ class SeedanceTextToVideoNode:
                 arguments["seed"] = seed
 
             result = ApiHandler.submit_and_get_result(
-                "fal-ai/bytedance/seedance/v1/lite/text-to-video", arguments
+                f"fal-ai/bytedance/seedance/v1/{variant}/text-to-video", arguments
             )
             video_url = result["video"]["url"]
             return (video_url,)
         except Exception as e:
             return ApiHandler.handle_video_generation_error(
-                "fal-ai/bytedance/seedance/v1/lite/text-to-video", str(e)
+                f"fal-ai/bytedance/seedance/v1/{variant}/text-to-video", str(e)
             )
 
 


### PR DESCRIPTION
Current ComfyUI-fal-API uses hardcoded url for Seedance fal-ai/bytedance/seedance/v1/lite/* and uses only lite version.

There is currently no way to use pro version of Seedance without code changes.

This PR updates it so that user can pick the model variants themselves.

<img width="1063" height="436" alt="image" src="https://github.com/user-attachments/assets/edfa34bb-f585-4a4c-a689-21d4ceee4494" />
