### PR TITLE
Add aspect ratio selection to Nano Banana image edit node

### DIFF
--- a/nodes/image_node.py
+++ b/nodes/image_node.py
@@ -1638,6 +1638,7 @@ class NanoBananaEdit:
                 "image_4": ("IMAGE",),
                 "num_images": ("INT", {"default": 1, "min": 1, "max": 4}),
                 "output_format": (["jpeg", "png"], {"default": "jpeg"}),
+                "aspect_ratio": (["21:9", "1:1", "4:3", "3:2", "2:3", "5:4", "4:5", "3:4", "16:9", "9:16"], {"default": "1:1"}),
             },
         }
 
@@ -1654,6 +1655,7 @@ class NanoBananaEdit:
         image_4=None,
         num_images=1,
         output_format="jpeg",
+        aspect_ratio="1:1",
     ):
         # Upload all provided images
         image_urls = []
@@ -1667,12 +1669,12 @@ class NanoBananaEdit:
                     print(f"Error: Failed to upload image {i} for Nano Banana Edit")
                     return ResultProcessor.create_blank_image()
 
-
         arguments = {
             "prompt": prompt,
             "image_urls": image_urls,
             "num_images": num_images,
             "output_format": output_format,
+            "aspect_ratio": aspect_ratio,
         }
 
         try:


### PR DESCRIPTION
Minor tweak to the Nano Banana image edit node adding support for selecting an aspect ratio, aligning with the latest Nano Banana update. This exposes aspect ratio options in the node UI so users can set their desired output proportions.