### PR TITLE
Add API key manager node

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,10 @@ After installation and configuration, restart ComfyUI. The new nodes will be ava
     - custom (Get model name from openrouter)
   - Supports various tasks such as image captioning, visual question answering, and more
 
+### Utilities
+
+- **FAL API Key Manager (fal)**: Switch between named fal API keys from the ComfyUI frontend. Keys are stored in browser localStorage and sent to the server before each queue execution. Falls back to config.ini or environment variable when no key is set.
+
 ## Troubleshooting
 
 If you encounter any errors during installation or usage, try the following:

--- a/__init__.py
+++ b/__init__.py
@@ -8,7 +8,10 @@ node_list = [
     "vlm_node",
     "trainer_node",
     "upscaler_node",
+    "key_manager_node",
 ]
+
+WEB_DIRECTORY = "./web"
 
 NODE_CLASS_MAPPINGS = {}
 NODE_DISPLAY_NAME_MAPPINGS = {}
@@ -23,4 +26,4 @@ for module_name in node_list:
     }
 
 
-__all__ = ["NODE_CLASS_MAPPINGS", "NODE_DISPLAY_NAME_MAPPINGS"]
+__all__ = ["NODE_CLASS_MAPPINGS", "NODE_DISPLAY_NAME_MAPPINGS", "WEB_DIRECTORY"]

--- a/nodes/fal_utils.py
+++ b/nodes/fal_utils.py
@@ -19,6 +19,7 @@ class FalConfig:
     _instance = None
     _client = None
     _key = None
+    _key_name = None
 
     def __new__(cls):
         if cls._instance is None:
@@ -61,6 +62,20 @@ class FalConfig:
         if self._client is None:
             self._client = SyncClient(key=self._key)
         return self._client
+
+    def set_key(self, key, name=None):
+        """Set a new API key at runtime, resetting the client."""
+        self._key = key
+        self._key_name = name
+        self._client = None
+        os.environ["FAL_KEY"] = key
+        print(f"FAL API key switched to: {name or 'unnamed'}")
+
+    def get_key_name(self):
+        """Get the display name of the active key."""
+        if self._key_name:
+            return self._key_name
+        return "config.ini / env"
 
     def get_key(self):
         """Get the FAL API key."""

--- a/nodes/key_manager_node.py
+++ b/nodes/key_manager_node.py
@@ -1,0 +1,76 @@
+import json
+import math
+
+from aiohttp import web
+from server import PromptServer
+
+from .fal_utils import FalConfig
+
+
+# ── REST routes ──────────────────────────────────────────────────────────────
+
+@PromptServer.instance.routes.post("/fal-api/set-key")
+async def set_key_route(request):
+    """Receive a key + name from the frontend and update the singleton."""
+    try:
+        data = await request.json()
+        key = data.get("key", "").strip()
+        name = data.get("name", "").strip()
+        if not key:
+            return web.json_response({"error": "No key provided"}, status=400)
+        FalConfig().set_key(key, name or None)
+        return web.json_response({"status": "ok", "active_key_name": FalConfig().get_key_name()})
+    except Exception as e:
+        return web.json_response({"error": str(e)}, status=500)
+
+
+@PromptServer.instance.routes.get("/fal-api/active-key-info")
+async def active_key_info_route(request):
+    """Return the display name of the active key (never the key itself)."""
+    return web.json_response({"active_key_name": FalConfig().get_key_name()})
+
+
+# ── ComfyUI Node ─────────────────────────────────────────────────────────────
+
+class FalApiKeyManager:
+    """Visual node for switching between named FAL API keys.
+
+    Keys are stored in browser localStorage — never serialised into the workflow.
+    The frontend JS extension POSTs the selected key to the server before each
+    queue execution, so all downstream nodes automatically use the right key.
+    """
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {},
+            "hidden": {
+                "selected_key_name": ("STRING", {"default": ""}),
+            },
+        }
+
+    RETURN_TYPES = ()
+    OUTPUT_NODE = True
+    FUNCTION = "run"
+    CATEGORY = "FAL/Utils"
+
+    @classmethod
+    def IS_CHANGED(cls, **kwargs):
+        return math.nan
+
+    def run(self, selected_key_name=""):
+        active = FalConfig().get_key_name()
+        PromptServer.instance.send_sync(
+            "fal-key-status",
+            {"active_key_name": active},
+        )
+        return {}
+
+
+NODE_CLASS_MAPPINGS = {
+    "FalApiKeyManager": FalApiKeyManager,
+}
+
+NODE_DISPLAY_NAME_MAPPINGS = {
+    "FalApiKeyManager": "FAL API Key Manager",
+}

--- a/web/fal_key_manager.js
+++ b/web/fal_key_manager.js
@@ -1,0 +1,311 @@
+import { app } from "../../scripts/app.js";
+import { api } from "../../scripts/api.js";
+
+// ── localStorage helpers ────────────────────────────────────────────────────
+
+const KEYS_STORAGE = "fal_api_keys";
+const ACTIVE_STORAGE = "fal_active_key_name";
+
+function loadKeys() {
+  try {
+    return JSON.parse(localStorage.getItem(KEYS_STORAGE)) || {};
+  } catch {
+    return {};
+  }
+}
+
+function saveKeys(keys) {
+  localStorage.setItem(KEYS_STORAGE, JSON.stringify(keys));
+}
+
+function getActiveKeyName() {
+  return localStorage.getItem(ACTIVE_STORAGE) || "";
+}
+
+function setActiveKeyName(name) {
+  localStorage.setItem(ACTIVE_STORAGE, name);
+}
+
+// ── Send key to server ──────────────────────────────────────────────────────
+
+async function pushActiveKeyToServer() {
+  const name = getActiveKeyName();
+  const keys = loadKeys();
+  const key = keys[name];
+  if (!key) return;
+  try {
+    await api.fetchApi("/fal-api/set-key", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ key, name }),
+    });
+  } catch (e) {
+    console.error("[FAL Key Manager] Failed to push key to server:", e);
+  }
+}
+
+// ── Queue-prompt hook ───────────────────────────────────────────────────────
+
+let hooked = false;
+function installQueueHook() {
+  if (hooked) return;
+  hooked = true;
+  const origQueue = app.queuePrompt.bind(app);
+  app.queuePrompt = async function (...args) {
+    await pushActiveKeyToServer();
+    return origQueue(...args);
+  };
+}
+
+// ── Manage-keys dialog ──────────────────────────────────────────────────────
+
+function showManageKeysDialog(node) {
+  const overlay = document.createElement("div");
+  Object.assign(overlay.style, {
+    position: "fixed",
+    inset: "0",
+    background: "rgba(0,0,0,0.5)",
+    zIndex: "100000",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+  });
+
+  const dialog = document.createElement("div");
+  Object.assign(dialog.style, {
+    background: "#1e1e1e",
+    color: "#ccc",
+    borderRadius: "8px",
+    padding: "20px",
+    minWidth: "380px",
+    maxWidth: "480px",
+    fontFamily: "sans-serif",
+    fontSize: "13px",
+    boxShadow: "0 8px 32px rgba(0,0,0,0.6)",
+  });
+
+  function render() {
+    const keys = loadKeys();
+    const names = Object.keys(keys);
+
+    dialog.innerHTML = "";
+
+    // Title
+    const title = document.createElement("h3");
+    title.textContent = "Manage FAL API Keys";
+    Object.assign(title.style, { margin: "0 0 14px", color: "#fff" });
+    dialog.appendChild(title);
+
+    // Existing keys list
+    if (names.length) {
+      const list = document.createElement("div");
+      Object.assign(list.style, { marginBottom: "14px" });
+      for (const n of names) {
+        const row = document.createElement("div");
+        Object.assign(row.style, {
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          padding: "6px 8px",
+          marginBottom: "4px",
+          background: "#2a2a2a",
+          borderRadius: "4px",
+        });
+
+        const info = document.createElement("span");
+        const preview = keys[n].slice(0, 8) + "...";
+        info.textContent = `${n}  (${preview})`;
+        row.appendChild(info);
+
+        const del = document.createElement("button");
+        del.textContent = "Remove";
+        Object.assign(del.style, {
+          background: "#c44",
+          color: "#fff",
+          border: "none",
+          borderRadius: "4px",
+          padding: "3px 10px",
+          cursor: "pointer",
+        });
+        del.onclick = () => {
+          const updated = loadKeys();
+          delete updated[n];
+          saveKeys(updated);
+          if (getActiveKeyName() === n) setActiveKeyName("");
+          render();
+          refreshNodeWidgets(node);
+        };
+        row.appendChild(del);
+        list.appendChild(row);
+      }
+      dialog.appendChild(list);
+    } else {
+      const empty = document.createElement("p");
+      empty.textContent = "No keys saved yet.";
+      Object.assign(empty.style, { color: "#888", marginBottom: "14px" });
+      dialog.appendChild(empty);
+    }
+
+    // Add-key form
+    const form = document.createElement("div");
+    Object.assign(form.style, {
+      display: "flex",
+      gap: "6px",
+      marginBottom: "14px",
+    });
+
+    const nameInput = document.createElement("input");
+    nameInput.placeholder = "Name";
+    Object.assign(nameInput.style, {
+      flex: "1",
+      padding: "6px",
+      background: "#333",
+      color: "#fff",
+      border: "1px solid #555",
+      borderRadius: "4px",
+    });
+
+    const keyInput = document.createElement("input");
+    keyInput.type = "password";
+    keyInput.placeholder = "fal-xxxx...";
+    Object.assign(keyInput.style, {
+      flex: "2",
+      padding: "6px",
+      background: "#333",
+      color: "#fff",
+      border: "1px solid #555",
+      borderRadius: "4px",
+    });
+
+    const addBtn = document.createElement("button");
+    addBtn.textContent = "Add";
+    Object.assign(addBtn.style, {
+      background: "#4a4",
+      color: "#fff",
+      border: "none",
+      borderRadius: "4px",
+      padding: "6px 14px",
+      cursor: "pointer",
+    });
+    addBtn.onclick = () => {
+      const n = nameInput.value.trim();
+      const k = keyInput.value.trim();
+      if (!n || !k) return;
+      const updated = loadKeys();
+      updated[n] = k;
+      saveKeys(updated);
+      render();
+      refreshNodeWidgets(node);
+    };
+
+    form.appendChild(nameInput);
+    form.appendChild(keyInput);
+    form.appendChild(addBtn);
+    dialog.appendChild(form);
+
+    // Close button
+    const closeBtn = document.createElement("button");
+    closeBtn.textContent = "Close";
+    Object.assign(closeBtn.style, {
+      background: "#555",
+      color: "#fff",
+      border: "none",
+      borderRadius: "4px",
+      padding: "6px 20px",
+      cursor: "pointer",
+      display: "block",
+      marginLeft: "auto",
+    });
+    closeBtn.onclick = () => overlay.remove();
+    dialog.appendChild(closeBtn);
+  }
+
+  render();
+  overlay.appendChild(dialog);
+  overlay.addEventListener("click", (e) => {
+    if (e.target === overlay) overlay.remove();
+  });
+  document.body.appendChild(overlay);
+}
+
+// ── Refresh combo widget on the node ────────────────────────────────────────
+
+function refreshNodeWidgets(node) {
+  if (!node) return;
+  const keys = loadKeys();
+  const names = Object.keys(keys);
+  const options = names.length ? names : ["(no keys)"];
+
+  const combo = node.widgets?.find((w) => w.name === "key_selector");
+  if (combo) {
+    combo.options.values = options;
+    const active = getActiveKeyName();
+    combo.value = names.includes(active) ? active : options[0];
+  }
+  node.setDirtyCanvas(true, true);
+}
+
+// ── Register the extension ──────────────────────────────────────────────────
+
+app.registerExtension({
+  name: "fal.ApiKeyManager",
+
+  async setup() {
+    installQueueHook();
+
+    // Listen for status events from the server node
+    api.addEventListener("fal-key-status", (event) => {
+      const data = event.detail;
+      const nodes = app.graph._nodes.filter(
+        (n) => n.type === "FalApiKeyManager"
+      );
+      for (const node of nodes) {
+        const w = node.widgets?.find((w) => w.name === "status_display");
+        if (w) {
+          w.value = `Active: ${data.active_key_name}`;
+          node.setDirtyCanvas(true, true);
+        }
+      }
+    });
+  },
+
+  async nodeCreated(node) {
+    if (node.comfyClass !== "FalApiKeyManager") return;
+
+    const keys = loadKeys();
+    const names = Object.keys(keys);
+    const options = names.length ? names : ["(no keys)"];
+    const active = getActiveKeyName();
+
+    // Key selector combo
+    const combo = node.addWidget(
+      "combo",
+      "key_selector",
+      names.includes(active) ? active : options[0],
+      function (value) {
+        if (value && value !== "(no keys)") {
+          setActiveKeyName(value);
+        }
+      },
+      { values: options }
+    );
+
+    // Status display
+    node.addWidget("text", "status_display", `Active: ${active || "default"}`, () => {}, {
+      multiline: false,
+      serialize: false,
+    });
+
+    // Manage Keys button
+    node.addWidget("button", "manage_keys", "Manage Keys", () => {
+      showManageKeysDialog(node);
+    });
+
+    // Push on first load if a key is already selected
+    if (active && keys[active]) {
+      pushActiveKeyToServer();
+    }
+
+    node.serialize_widgets = false;
+  },
+});


### PR DESCRIPTION
- Add FalApiKeyManager node for switching between named fal API keys from the ComfyUI frontend
- Keys stored in browser localStorage, sent to server before each queue execution
- Falls back to config.ini or environment variable when no key is set
- Update README with new Utilities section