### PR TITLE
Gpt-image-2-&-gpt-image-2-edit-]-addition

### DIFF
--- a/nodes/image_node.py
+++ b/nodes/image_node.py
@@ -2291,6 +2291,219 @@ class GPTImage15:
             return ApiHandler.handle_image_generation_error("GPT-Image 1.5", e)
 
 
+class GPTImage2Edit:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "prompt": ("STRING", {"default": "", "multiline": True}),
+                "image_1": ("IMAGE",),
+                "image_size": (
+                    [
+                        "square_hd",
+                        "square",
+                        "portrait_4_3",
+                        "portrait_16_9",
+                        "landscape_4_3",
+                        "landscape_16_9",
+                        "custom",
+                    ],
+                    {"default": "custom"},
+                ),
+                "width": ("INT", {"default": 3840, "min": 768, "max": 4096}),
+                "height": ("INT", {"default": 2160, "min": 768, "max": 4096}),
+            },
+            "optional": {
+                "image_2": ("IMAGE",),
+                "image_3": ("IMAGE",),
+                "image_4": ("IMAGE",),
+                "image_5": ("IMAGE",),
+                "image_6": ("IMAGE",),
+                "image_7": ("IMAGE",),
+                "image_8": ("IMAGE",),
+                "image_9": ("IMAGE",),
+                "image_10": ("IMAGE",),
+                "image_11": ("IMAGE",),
+                "image_12": ("IMAGE",),
+                "image_13": ("IMAGE",),
+                "image_14": ("IMAGE",),
+                "image_15": ("IMAGE",),
+                "image_16": ("IMAGE",),                 
+                "mask_image": ("IMAGE",),
+                "background": (["auto", "transparent", "opaque"], {"default": "opaque"}),
+                "quality": (["low", "medium", "high"], {"default": "high"}),
+                "input_fidelity": (["low", "high"], {"default": "high"}),
+                "num_images": ("INT", {"default": 1, "min": 1, "max": 4}),
+                "output_format": (["jpeg", "png", "webp"], {"default": "png"}),
+                "sync_mode": ("BOOLEAN", {"default": False}),
+            },
+        }
+
+    RETURN_TYPES = ("IMAGE",)
+    FUNCTION = "edit_image"
+    CATEGORY = "FAL/Image"
+
+    def edit_image(
+        self,
+        prompt,
+        image_1,
+        image_size,
+        width,       
+        height,      
+        image_2=None,
+        image_3=None,
+        image_4=None,
+        image_5=None,
+        image_6=None,
+        image_7=None,
+        image_8=None,
+        image_9=None,
+        image_10=None,
+        image_11=None,
+        image_12=None,
+        image_13=None,
+        image_14=None,
+        image_15=None,
+        image_16=None,        
+        mask_image=None,
+        background="opaque",
+        quality="high",
+        input_fidelity="high",
+        num_images=1,
+        output_format="png",
+        sync_mode=False,
+    ):
+        model_name = "GPT-Image 2 Edit"
+
+        image_urls = []
+        for i, img in enumerate(
+            [
+                image_1,
+                image_2,
+                image_3,
+                image_4,
+                image_5,
+                image_6,
+                image_7,
+                image_8,
+                image_9,
+                image_10,
+                image_11,
+                image_12,
+                image_13,
+                image_14,
+                image_15,
+                image_16,
+            ],
+            1,
+        ):
+            if img is not None:
+                url = ImageUtils.upload_image(img)
+                if url:
+                    image_urls.append(url)
+                else:
+                    print(f"Error: Failed to upload image {i} for {model_name}")
+                    return ResultProcessor.create_blank_image()
+
+        if len(image_urls) == 0:
+            print(f"Error: No valid images provided for {model_name}")
+            return ResultProcessor.create_blank_image()
+
+        arguments = {
+            "prompt": prompt,
+            "image_urls": image_urls,
+            "background": background,
+            "quality": quality,
+            "input_fidelity": input_fidelity,
+            "num_images": num_images,
+            "output_format": output_format,
+            "sync_mode": sync_mode,
+        }
+
+        if image_size == "custom":
+            arguments["image_size"] = {"width": width, "height": height}
+        else:
+            arguments["image_size"] = image_size
+
+        if mask_image is not None:
+            mask_url = ImageUtils.upload_image(mask_image)
+            if mask_url:
+                arguments["mask_image_url"] = mask_url
+
+        try:
+            result = ApiHandler.submit_and_get_result("fal-ai/gpt-image-2/edit", arguments)
+            return ResultProcessor.process_image_result(result)
+        except Exception as e:
+            return ApiHandler.handle_image_generation_error(model_name, e)
+
+
+class GPTImage2:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "prompt": ("STRING", {"default": "", "multiline": True}),
+            },
+            "optional": {
+                "image_size": (
+                    [
+                        "square_hd",
+                        "square",
+                        "portrait_4_3",
+                        "portrait_16_9",
+                        "landscape_4_3",
+                        "landscape_16_9",
+                        "custom",
+                    ],
+                    {"default": "custom"},
+                ),
+                "width": ("INT", {"default": 3840, "min": 768, "max": 4096}),
+                "height": ("INT", {"default": 2160, "min": 768, "max": 4096}),
+                "background": (["auto", "transparent", "opaque"], {"default": "opaque"}),
+                "quality": (["low", "medium", "high"], {"default": "high"}),
+                "num_images": ("INT", {"default": 1, "min": 1, "max": 4}),
+                "output_format": (["jpeg", "png", "webp"], {"default": "png"}),
+                "sync_mode": ("BOOLEAN", {"default": False}),
+            },
+        }
+
+    RETURN_TYPES = ("IMAGE",)
+    FUNCTION = "generate_image"
+    CATEGORY = "FAL/Image"
+
+    def generate_image(
+        self,
+        prompt,
+        image_size="custom",
+        width=3840,
+        height=2160,
+        background="auto",
+        quality="high",
+        num_images=1,
+        output_format="png",
+        sync_mode=False,
+    ):
+        arguments = {
+            "prompt": prompt,
+            "background": background,
+            "quality": quality,
+            "num_images": num_images,
+            "output_format": output_format,
+            "sync_mode": sync_mode,
+        }
+
+        if image_size == "custom":
+            arguments["image_size"] = {"width": width, "height": height}
+        else:
+            arguments["image_size"] = image_size
+
+        try:
+            result = ApiHandler.submit_and_get_result("fal-ai/gpt-image-2", arguments)
+            return ResultProcessor.process_image_result(result)
+        except Exception as e:
+            return ApiHandler.handle_image_generation_error("GPT-Image 2", e)
+
+
 # Node class mappings
 NODE_CLASS_MAPPINGS = {
     "Ideogramv3_fal": Ideogramv3,
@@ -2354,4 +2567,6 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     "Dreamina31TextToImage_fal": "Dreamina v3.1 Text-to-Image (fal)",
     "GPTImage15Edit_fal": "GPT-Image 1.5 Edit (fal)",
     "GPTImage15_fal": "GPT-Image 1.5 (fal)",
+    "GPTImage2Edit_fal": "GPT-Image 2 Edit (fal)",
+    "GPTImage2_fal": "GPT-Image 2.0 (fal)",
 }


### PR DESCRIPTION
I've added the 16 image inputs and a custom image size option ( based on what was added on the seedream 4.0 node ) along with traditional fal image options.